### PR TITLE
fix: remove upgrade button and suggestions card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@edx/brand-edx.org",
+  "name": "@mitol/brand-mitol-residential",
   "version": "1.0.0",
-  "description": "A package containing brand elements and SASS themes for edx.org",
+  "description": "A package containing brand elements and SASS themes for MIT Residential",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/edx/brand-edx.org.git"
+    "url": "git+https://github.com/mitodl/brand-mitol-residential.git"
   },
-  "author": "edX",
-  "license": "UNLICENSED",
+  "author": "MIT",
+  "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/edx/brand-edx.org/issues"
+    "url": "https://github.com/mitodl/brand-mitol-residential/issues"
   },
-  "homepage": "https://github.com/edx/brand-edx.org#readme",
+  "homepage": "https://github.com/mitodl/brand-mitol-residential#readme",
   "publishConfig": {
     "access": "public"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mitol/brand-mitol-residential",
   "version": "1.0.0",
-  "description": "A package containing brand elements and SASS themes for MIT Residential",
+  "description": "A package containing brand elements and SASS themes for Residential MITx",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mitodl/brand-mitol-residential.git"

--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -394,3 +394,17 @@ a.inline-link {
     color: $gray-900;
   }
 }
+// MIT-Residential changes
+.course-card {
+  .card {
+    .btn-outline-primary {
+      display: None;
+    }
+  }
+}
+
+#looking-for-challenge-widget {
+  display: None;
+}
+
+


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1499

# Description (What does it do?)
- This is going to override the brand for residential changes
- This removed the upgrade card based on the CSS class because there is no id set to that component
- Removed the suggestions card based on the CSS class
- Add config for our npm package details

# Screenshots (if appropriate):

<img width="1790" alt="image" src="https://github.com/mitodl/brand-mitol-residential/assets/34372316/88e07bc6-324c-4072-96e0-04e5e5c45a86">

# How can this be tested?

_I'd recommend_ setting up the learner dashboard MFE locally, You can follow the steps https://github.com/openedx/frontend-app-learner-dashboard. You can skip the configuration in settings etc, Just spin up the MFE and you should start seeing the dashboard if successful.

- Before moving to this PR, Make sure to notice that you see `Upgrade` button on courses and a card on the right side for suggested courses `Looking for a new challenge`
- Now, Somewhere in the learner dashboard MFE, checkout this branch
- Create a `module.config.js` under the main directory of the learner dashboard directory and place the code below, This will override the brand, And use your local copy for `@edx/brand`.
```
module.exports = {
  localModules: [
    { moduleName: '@edx/brand', dir: './brand-mitol-residential'},
  ],
}
```

# Additional Context
There are some details mentioned in the comment on https://github.com/mitodl/hq/issues/1499 that you might want to take a look at to get the context on available options.

# Next steps:

Once we merge this PR, we'll either upload this as a new npm package or ad configuration in ol-infrastructure to override `@edx/brand` package with our copy