### PR TITLE
fix: remove grade info banner from course cards

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -394,11 +394,17 @@ a.inline-link {
     color: $gray-900;
   }
 }
+
 // MIT-Residential changes
 .course-card {
   .card {
     .btn-outline-primary {
-      display: None;
+      display: none;
+    }
+  }
+  .course-card-banners {
+    div[role=alert] {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
# What are the relevant tickets?

https://github.com/mitodl/hq/issues/1599

# Description (What does it do?)
- Modifies the CSS in the overridden brand for frontend-app-learner-dashboard to hide the grade info banner in the course card.

# Screenshots (if appropriate):

- [x] Desktop screenshots
- [x] Mobile width screenshots

<img width="1441" alt="image" src="https://github.com/mitodl/brand-mitol-residential/assets/34372316/4d2cd5a8-0d84-4532-b185-51d00c8e01e6">

<img width="495" alt="image" src="https://github.com/mitodl/brand-mitol-residential/assets/34372316/cc803f0f-2774-4045-96e4-49b45490374b">

# How can this be tested?
Follow the same steps as mentioned in https://github.com/mitodl/brand-mitol-residential/pull/1 to ad this repo as brand to `frontend-app-learner-dashboard`.

- CHeck that you don't see the grades required info on course cards.

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
